### PR TITLE
Added author to RSS, made more configurable, throw error in createAssets for missing dir

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	port: 8080,
+	buildPath: "./build"
+}

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-	port: 8080,
+	port: 80,
 	buildPath: "./build"
 }

--- a/main.js
+++ b/main.js
@@ -116,6 +116,8 @@ function createAssets (configpath, builddir, cb) {
       ;
   
     fs.readdir(path.join(builddir, 'db'), function (err, files) {
+	  if(err) throw err;
+
       files.sort()
       files.reverse()
       files = files.slice(0, 10).map(function (p) {return path.join(builddir, 'db', p)})

--- a/main.js
+++ b/main.js
@@ -116,7 +116,7 @@ function createAssets (configpath, builddir, cb) {
       ;
   
     fs.readdir(path.join(builddir, 'db'), function (err, files) {
-	  if(err) throw err;
+	  if(err) console.log(err);
 
       files.sort()
       files.reverse()

--- a/server.js
+++ b/server.js
@@ -1,1 +1,2 @@
-require('./main').run(80, '/home/node/planetbuild');
+var config = require("./config");
+require('./main').run(config.port, config.buildPath);

--- a/templates/rss.mustache
+++ b/templates/rss.mustache
@@ -16,6 +16,7 @@
 	  <item>
 	    <title>{{title}}</title>
 			<link>{{link}}</link>
+			<author>{{site.author}}</author>
 			<guid>{{guid}}</guid>
 			<description>
 			  {{description}}


### PR DESCRIPTION
Added author tag to RSS feed
Created config.js for server to read config (port, builddir) from.
createAssets didn't throw error if builddir was missing (instead threw exception on files.sort)
