### PR TITLE
Strip HTML from post titles and clean out some bad feeds

### DIFF
--- a/feedstream.js
+++ b/feedstream.js
@@ -3,6 +3,7 @@ var stream = require('stream')
   , util = require('util')
   , rfc822 = require('./rfc822')
   , request = require('request')
+  , stripHtml = require('resanitize').stripHtml
   , r = request.defaults({headers:{accept:'application/rss+xml'}})
   ;
   
@@ -83,6 +84,7 @@ function FeedStream (strict) {
                   console.error('Feed item does not have title: '+post.link)
                   return
                 }
+                post.title = stripHtml(post.title);
                 self.emit('post', post)
                 parser.onattribute = null;
                 parser.onopentag = function (node) {
@@ -175,6 +177,7 @@ function FeedStream (strict) {
           }
           var onclose = function () {
             if (Object.keys(post).length) {
+              post.title = stripHtml(post.title);
               self.emit('post', post)
               post = {}
             }

--- a/main.js
+++ b/main.js
@@ -44,7 +44,8 @@ function build (name, blog, builddir, cb) {
       cb = null
     }
   })
-  feed.on('error', function () {
+  feed.on('error', function (err) {
+    console.error('%s - build error (%s) - [%s]: %s', new Date(), blog.feed, err, err.code)
     if (cb) cb();
     cb = null;
   })

--- a/node_modules/resanitize/LICENSE
+++ b/node_modules/resanitize/LICENSE
@@ -1,0 +1,24 @@
+----------------------------------------------------------------------
+resanitize is released under the MIT License
+Copyright (c) 2012 Dan MacTough - http://yabfog.com
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/resanitize/README.md
+++ b/node_modules/resanitize/README.md
@@ -1,0 +1,19 @@
+#  Resanitize - Regular expression-based HTML sanitizer and ad remover, geared toward RSS feed descriptions
+
+This node.js module provides functions for removing unsafe parts and ads from
+HTML. I am using it for the &lt;description&gt; element of RSS feeds.
+
+## Installation
+
+npm install resanitize
+
+## Usage
+
+```javascript
+
+    var resanitize = require('resanitize')
+      , html = '<div style="border: 400px solid pink;">Headline</div>'
+      ;
+
+    resanitize(html); // => '<div>Headline</div>'
+```

--- a/node_modules/resanitize/package.json
+++ b/node_modules/resanitize/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "resanitize",
+  "author": {
+    "name": "Dan MacTough",
+    "email": "danmactough@gmail.com"
+  },
+  "description": "Regular expression-based HTML sanitizer and ad remover, geared toward RSS feed descriptions",
+  "version": "0.1.10",
+  "keywords": [
+    "sanitize",
+    "html",
+    "regexp",
+    "security"
+  ],
+  "homepage": "http://github.com/danmactough/node-resanitize",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/danmactough/node-resanitize.git"
+  },
+  "bugs": {
+    "url": "http://github.com/danmactough/node-resanitize/issues"
+  },
+  "main": "./resanitize.js",
+  "engines": {
+    "node": ">= 0.6.0"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "readme": "#  Resanitize - Regular expression-based HTML sanitizer and ad remover, geared toward RSS feed descriptions\n\nThis node.js module provides functions for removing unsafe parts and ads from\nHTML. I am using it for the &lt;description&gt; element of RSS feeds.\n\n## Installation\n\nnpm install resanitize\n\n## Usage\n\n```javascript\n\n    var resanitize = require('resanitize')\n      , html = '<div style=\"border: 400px solid pink;\">Headline</div>'\n      ;\n\n    resanitize(html); // => '<div>Headline</div>'\n```",
+  "readmeFilename": "README.md",
+  "_id": "resanitize@0.1.10",
+  "_from": "resanitize@"
+}

--- a/node_modules/resanitize/resanitize.js
+++ b/node_modules/resanitize/resanitize.js
@@ -1,0 +1,263 @@
+/*!
+ * resanitize - Regular expression-based HTML sanitizer and ad remover, geared toward RSS feed descriptions
+ * Copyright(c) 2012 Dan MacTough <danmactough@gmail.com>
+ * All rights reserved.
+ */
+
+/**
+ * Remove unsafe parts and ads from HTML
+ *
+ * Example:
+ *
+ *      var resanitize = require('resanitize');
+ *      resanitize('<div style="border: 400px solid pink;">Headline</div>');
+ *      // => '<div>Headline</div>'
+ *
+ * References:
+ * - http://en.wikipedia.org/wiki/C0_and_C1_control_codes
+ * - http://en.wikipedia.org/wiki/Unicode_control_characters
+ * - http://www.utf8-chartable.de/unicode-utf8-table.pl
+ *
+ * @param {String|Buffer} HTML string to sanitize
+ * @return {String} sanitized HTML
+ * @api public
+ */
+function resanitize (str) {
+  if ('string' !== typeof str) {
+    if (Buffer.isBuffer(str)) {
+      str = str.toString();
+    }
+    else {
+      throw new TypeError('Invalid argument: must be String or Buffer');
+    }
+  }
+  str = stripAsciiCtrlChars(str);
+  str = stripExtendedCtrlChars(str);
+  str = fixSpace(str);
+  str = stripComments(str);
+  str = stripAds(str); // It's important that this comes before the remainder
+                       // because it matches on certain attribute values that
+                       // get stripped below.
+  str = fixImages(str);
+  str = stripUnsafeTags(str);
+  str = stripUnsafeAttrs(str);
+  return str;
+}
+module.exports = resanitize;
+
+/**
+ * Replace UTF-8 non-breaking space with a regular space and strip null bytes
+ */
+function fixSpace (str) {
+  return str.replace(/\u00A0/g, ' ') // Unicode non-breaking space
+            .replace(/[\u2028\u2029]/g, '') // UCS newline characters
+            .replace(/\0/g, '');
+}
+module.exports.fixSpace = fixSpace;
+
+/**
+ * Strip superfluous whitespace
+ */
+function stripHtmlExtraSpace (str) {
+  return str.replace(/<(div|p)[^>]*?>\s*?(?:<br[^>]*?>)*?\s*?<\/\1>/gi, '')
+            .replace(/<(div|span)[^>]*?>\s*?<\/\1>/gi, '');
+}
+module.exports.stripHtmlExtraSpace = stripHtmlExtraSpace;
+
+/**
+ * Strip ASCII control characters
+ */
+function stripAsciiCtrlChars (str) {
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+/g, '');
+}
+module.exports.stripAsciiCtrlChars = stripAsciiCtrlChars;
+
+/**
+ * Strip ISO 6429 control characters
+ */
+function stripExtendedCtrlChars (str) {
+  return str.replace(/[\u0080-\u009F]+/g, '');
+}
+module.exports.stripExtendedCtrlChars = stripExtendedCtrlChars;
+
+/**
+ * Strip HTML comments
+ */
+function stripComments (str) {
+  return str.replace(/<!--[^>]*?>.*?<![^>]*?-->/g, '');
+}
+module.exports.stripComments = stripComments;
+
+/**
+ * Permit only the provided attributes to remain in the tag
+ */
+function filterAttrs () {
+  var allowed = [];
+  if (Array.isArray(arguments[0])) {
+    allowed = arguments[0];
+  } else {
+    allowed = Array.prototype.slice.call(arguments);
+  }
+  return function (attr, name) {
+    if ( ~allowed.indexOf(name && name.toLowerCase()) ) {
+      return attr;
+    } else {
+      return '';
+    }
+  };
+}
+module.exports.filterAttrs = filterAttrs;
+
+/**
+ * Strip the provided attributes from the tag
+ */
+function stripAttrs () {
+  var banned = [];
+  if (Array.isArray(arguments[0])) {
+    banned = arguments[0];
+  } else {
+    banned = Array.prototype.slice.call(arguments);
+  }
+  return function (attr, name) {
+    if ( ~banned.indexOf(name && name.toLowerCase()) ) {
+      return '';
+    } else {
+      return attr;
+    }
+  };
+}
+module.exports.stripAttrs = stripAttrs;
+
+/**
+ * Filter an HTML opening or self-closing tag
+ */
+function filterTag (nextFilter) {
+  return function (rematch) {
+    if ('function' === typeof nextFilter) {
+      rematch = rematch.replace(/(\S+)=("|')[^>]+?\2/g, nextFilter);
+    }
+    // Cleanup extra whitespace
+    return rematch.replace(/\s+/g, ' ')
+                  .replace(/ (\/)?>/, '$1>');
+  };
+}
+module.exports.filterTag = filterTag;
+
+function fixImages (str) {
+  return str.replace(/(<img[^>]*?>)/g, filterTag(filterAttrs('src', 'alt', 'title', 'height', 'width')) );
+}
+module.exports.fixImages = fixImages;
+
+function stripUnsafeAttrs (str) {
+  var unsafe = [ 'id'
+               , 'class'
+               , 'style'
+               , 'clear'
+               , 'target'
+               , 'onclick'
+               , 'ondblclick'
+               , 'onmousedown'
+               , 'onmousemove'
+               , 'onmouseover'
+               , 'onmouseout'
+               , 'onmouseup'
+               , 'onkeydown'
+               , 'onkeypress'
+               , 'onkeyup'
+               , 'onabort'
+               , 'onerror'
+               , 'onload'
+               , 'onresize'
+               , 'onscroll'
+               , 'onunload'
+               , 'onblur'
+               , 'onchange'
+               , 'onfocus'
+               , 'onreset'
+               , 'onselect'
+               , 'onsubmit'
+               ];
+  return str.replace(/<([^ >]+?) [^>]*?>/g, filterTag(stripAttrs(unsafe)));
+}
+module.exports.stripUnsafeAttrs = stripUnsafeAttrs;
+
+function stripUnsafeTags (str) {
+  return str.replace(/<form[^>]*?>[\s\S]*?<\/form>/gi, '')
+            .replace(/<input[^>]*?>[\s\S]*?<\/input>/gi, '')
+            .replace(/<\/?(?:form|input|font|blink)[^>]*?>/gi, '')
+            // These are XSS/security risks
+            .replace(/<script[^>]*?>[\s\S]*?<\/script>/gi, '')
+            .replace(/<style[^>]*?>[\s\S]*?<\/style>/gi, '') // shouldn't work anyway...
+            .replace(/<comment[^>]*?>[\s\S]*?<\/comment>/gi, '')
+            .replace(/<plaintext[^>]*?>[\s\S]*?<\/plaintext>/gi, '')
+            .replace(/<xmp[^>]*?>[\s\S]*?<\/xmp>/gi, '')
+            .replace(/<\/?(?:link|listing|meta|body|frame|frameset)[^>]*?>/gi, '')
+            // Delete iframes, except those inserted by Google in lieu of video embeds
+            .replace(/<iframe(?![^>]*?src=("|')\S+?reader.googleusercontent.com\/reader\/embediframe.+?\1)[^>]*?>[\s\S]*?<\/iframe>/gi, '')
+            ;
+}
+module.exports.stripUnsafeTags = stripUnsafeTags;
+
+function stripAds (str) {
+  return str.replace(/<div[^>]*?class=("|')snap_preview\1[^>]*?>(?:<br[^>]*?>)?([\s\S]*?)<\/div>/gi, '$2')
+            .replace(/<div[^>]*?class=("|')(?:feedflare|zemanta-pixie)\1[^>]*?>[\s\S]*?<\/div>/gi, '')
+            .replace(/<!--AD BEGIN-->[\s\S]*?<!--AD END-->\s*/gi, '')
+            .replace(/<table[^>]*?>[\s\S]*?<\/table>\s*?<div[^>]*?>[\s\S]*?Ads by Pheedo[\s\S]*?<\/div>/gi, '')
+            .replace(/<table[^>]*?>.*?<img[^>]*?src=("|')[^>]*?advertisement[^>]*?\1.*?>.*?<\/table>/gi, '')
+            .replace(/<br[^>]*?>\s*?<br[^>]*?>\s*?<span[^>]*?class=("|')advertisement\1[^>]*?>[\s\S]*?<\/span>[\s\S]*<div[^>]*?>[\s\S]*?Ads by Pheedo[\s\S]*?<\/div>/gi, '')
+            .replace(/<br[^>]*?>\s*?<br[^>]*?>\s*?(?:<[^>]+>\s*)*?<hr[^>]*?>\s*?<div[^>]*?>(?:Featured Advertiser|Presented By:)<\/div>[\s\S]*<div[^>]*?>[\s\S]*?(?:Ads by Pheedo|ads\.pheedo\.com)[\s\S]*?<\/div>/gi, '')
+            .replace(/<br[^>]*?>\s*?<br[^>]*?>\s*?<a[^>]*?href=("|')http:\/\/[^>]*?\.?(?:pheedo|pheedcontent)\.com\/[^>]*?\1[\s\S]*?<\/a>[\s\S]*$/gim, '')
+            .replace(/<div[^>]*?class=("|')cbw snap_nopreview\1[^>]*?>[\s\S]*$/gim, '')
+            .replace(/<div><a href=(?:"|')http:\/\/d\.techcrunch\.com\/ck\.php[\s\S]*?<\/div> */gi, '')
+            .replace(/<(p|div)[^>]*?>\s*?<a[^>]*?href=("|')[^>]+?\2[^>]*?><img[^>]*?src=("|')http:\/\/(?:feedads\.googleadservices|feedproxy\.google|feeds2?\.feedburner)\.com\/(?:~|%7e)[^>]*?\/[^>]+?\3[^>]*?>[\s\S]*?<\/\1>/gi, '')
+            .replace(/<(p|div)[^>]*?>\s*?<a[^>]*?href=("|')[^>]+?\2[^>]*?><img[^>]*?src=("|')http:\/\/feeds\.[^>]+?\.[^>]+?\/(?:~|%7e)[^>]\/[^>]+?\3[^>]*?>[\s\S]*?<\/\1>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/feeds\.[^>]+?\.[^>]+?\/(?:~|%7e)[a-qs-z]\/[^>]+?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/[^>]*?\.?addtoany\.com\/[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/feeds\.wordpress\.com\/[\.\d]+?\/(?:comments|go[\s\S]*)\/[^>]+?\1[\s\S]*?<\/a> ?/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/[^>]*?\.?doubleclick\.net\/[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/[^>]*?\.?fmpub\.net\/adserver\/[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/[^>]*?\.?eyewonderlabs\.com\/[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/[^>]*?\.?pheedo\.com\/[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<a[^>]*?href=("|')http:\/\/api\.tweetmeme\.com\/share\?[^>]*?\1[\s\S]*?<\/a>/gi, '')
+            .replace(/<p><a[^>]*?href=("|')http:\/\/rss\.cnn\.com\/+?(?:~|%7e)a\/[^>]*?\1[\s\S]*?<\/p>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/feeds\.[^>]+?\.[^>]+?\/(?:~|%7e)r\/[^>]+?\1[\s\S]*?>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/rss\.nytimes\.com\/c\/[^>]*?\1.*?>.*$/gim, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/feeds\.washingtonpost\.com\/c\/[^>]*?\1.*?>.*$/gim, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/[^>]*?\.?feedsportal\.com\/c\/[^>]*?\1.*?>.*$/gim, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/(?:feedads\.googleadservices|feedproxy\.google|feeds2\.feedburner)\.com\/(?:~|%7e)r\/[^>]+?\1[\s\S]*?>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/rss\.cnn\.com\/~r\/[^>]*?\1[\s\S]*?>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/[^>]*?\.?fmpub\.net\/adserver\/[^>]*?\1[\s\S]*?>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/[^>]*?\.?pheedo\.com\/[^>]*?\1[\s\S]*?>/gi, '')
+            .replace(/<img[^>]*?src=("|')http:\/\/stats\.wordpress\.com\/[\w]\.gif\?[^>]*?\1[\s\S]*?>/gi, '')
+            .replace(/<p><strong><em>Crunch Network[\s\S]*?<\/p>/gi, '')
+            .replace(/<embed[^>]*?castfire_player[\s\S]*?> *?(<\/embed>)?/gi, '')
+            .replace(/<embed[^>]*?src=("|')[^>]*?castfire\.com[^>]+?\1[\s\S]*?> *?(<\/embed>)?/gi, '')
+            .replace(/<p align=("|')right\1><em>Sponsor<\/em>[\s\S]*?<\/p>/gi, '')
+            .replace(/<div [\s\S]*?<img [^>]*?src=(?:"|')[^>]*?\/share-buttons\/[\s\S]*?<\/div>[\s]*/gi, '')
+            // This is that annoying footer in every delicious item
+            .replace(/<span[^>]*?>\s*?<a[^>]*?href=("|')[^\1]+?src=feed_newsgator\1[^>]*?>[\s\S]*<\/span>/gi, '')
+            // This is the annoying footer from ATL
+            .replace(/<p[^>]*?><strong><a[^>]*?href=("|')[^>]*?abovethelaw\.com\/[\s\S]+?\1[^>]*?>Continue reading[\s\S]*<\/p>/gi, '')
+            // This is the annoying link at the end of WaPo articles
+            .replace(/<a[^>]*?>Read full article[\s\S]*?<\/a>/gi, '')
+            // These ads go...
+            .replace(/<div[^>]*?><a[^>]*?href=("|')[^>]*?crunchbase\.com\/company\/[\s\S]+?\1[^>]*?>[\s\S]*?<div[\s\S]*?>Loading information about[\s\S]*?<\/div>/gi, '')
+            .replace(/<div[^>]*?class=("|')cb_widget_[^>]+?\1[\s\S]*?><\/div>/gi, '')
+            .replace(/<div[^>]*?class=("|')cb_widget_[^>]+?\1[\s\S]*?>[\s\S]*?<\/div>/gi, '')
+            // Before these
+            .replace(/<a[^>]*?href=("|')[^>]*?crunchbase\.com\/\1[\s\S]*?<\/a>\s*/gi, '')
+            .replace(/<div[^>]*?class=("|')cb_widget\1[^>]*?>[\s\S]*?<\/div>/gi, '')
+            // Clean up some empty things
+            //.replace(/<(div|p|span)[^>]*?>(\s|<br *?\/?>|(?R))*?<\/\1>/gi, '')
+            .replace(/(\s|<br[^>]*?\/?>)*$/gim, '')
+            ;
+}
+module.exports.stripAds = stripAds;
+
+/**
+ * Dumbly strip angle brackets
+ */
+function stripHtml (str) {
+  return str.replace(/<.*?>/g, '');
+}
+module.exports.stripHtml = stripHtml;

--- a/nodeplanet/config.json
+++ b/nodeplanet/config.json
@@ -110,11 +110,6 @@
       "author": "Nuno Job",
       "link": "http://writings.nunojob.com/"
     },
-    "Dave Stevens": {
-      "feed": "http://davestevens.us/feed",
-      "author": "Dave Stevens",
-      "link": "http://davestevens.us"
-    },
     "Shape Shed": {
       "feed": "http://feeds.shapeshed.com/shapeshed",
       "author": "George Ornbo",

--- a/nodeplanet/config.json
+++ b/nodeplanet/config.json
@@ -50,11 +50,6 @@
       "author": "Bocoup",
       "link": "http://weblog.bocoup.com"
     },
-    "بلاگ ند": {
-      "feed": "http://nodejs.ir/blog/feed.xml",
-      "author": "Morteza Milani",
-      "link": "http://nodejs.ir"
-    },
     "Too Tall Nate": {
       "feed": "https://tootallnate.net/feed.xml",
       "author": "Nathan Rajlich",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "version": "0.0.1-33",
   "bundleDependencies": [
     "request",
-    "sax"
+    "sax",
+    "resanitize"
   ],
   "engines": {
     "node": "v0.6.x"


### PR DESCRIPTION
- strips HTML from post titles so that this:

![image](https://f.cloud.github.com/assets/357481/165334/1b28007a-793a-11e2-85b8-029ce3121dfc.png)

becomes this:

![image](https://f.cloud.github.com/assets/357481/165336/35d4e866-793a-11e2-8dc4-04546254c117.png)
- removes 2 feeds that were causing errors (for different reasons)
- adds a little logging to the error handler to help track down troublesome feeds
- `node test.js all` passes!
